### PR TITLE
Fix Notes property typo

### DIFF
--- a/app/Http/Controllers/NotesController.php
+++ b/app/Http/Controllers/NotesController.php
@@ -7,7 +7,7 @@ use App\Notes;
 
 class NotesController extends Controller
 {
-    protected $_resouce_path;
+    protected $_resource_path;
     
     public function __construct()
     {

--- a/app/Notes.php
+++ b/app/Notes.php
@@ -13,8 +13,8 @@ class Notes extends Model
     public $timestamps = true;
 
     protected $casts = [
-        'title'             => 'string',
-        'description'       => 'text',
-        'status'            => 'string'
+        'title'       => 'string',
+        'description' => 'string',
+        'status'      => 'string',
     ];
 }


### PR DESCRIPTION
## Summary
- fix `_resource_path` typo in `NotesController`
- fix description type casting in `Notes` model

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427fbd7c60832ea98ebe47c50e0ab9